### PR TITLE
URGENT: Missing Import from input.css needed for functionality.

### DIFF
--- a/app/templates/input.css
+++ b/app/templates/input.css
@@ -1,3 +1,6 @@
+@import "tailwindcss";
+
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
Input.css missing '@import "tailwindcss' which is required for our tailwind to work via ./tailwindcss -i app/templates/input.css -o app/static/tailwind.css --watch 

Let me know if I am mistaken?